### PR TITLE
Updating installation instructions.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -189,10 +189,6 @@ Activate the virtual environment:
    <li> On Linux/Mac: on the command line <code>source path_to_anaconda3/bin/activate sitkpySPIE19</code></li>
   </ul>
 </li>
-<li>
-On the command line:
-<code>jupyter nbextension enable --py --sys-prefix widgetsnbextension</code>
-</li>
 
 <li>
 Go over the setup notebook (requires internet connectivity). This notebook checks the environment setup and downloads


### PR DESCRIPTION
The ipywidgets extension is enabled by default in Anaconda (no need to
explicitly enable).